### PR TITLE
Fix clippy

### DIFF
--- a/src/domobroker.rs
+++ b/src/domobroker.rs
@@ -124,7 +124,7 @@ impl DomoBroker {
                 topic_name,
                 topic_uuid,
             } => {
-                let _ret = self.domo_cache.delete_value(&topic_name, &topic_uuid).await;
+                self.domo_cache.delete_value(&topic_name, &topic_uuid).await;
                 println!("WebSocket RequestDeleteTopicUUID");
             }
 
@@ -135,15 +135,14 @@ impl DomoBroker {
             } => {
                 println!("WebSocket RequestPostTopicUUID");
 
-                let _ret = self
-                    .domo_cache
+                self.domo_cache
                     .write_value(&topic_name, &topic_uuid, value.clone())
                     .await;
             }
 
             SyncWebSocketDomoRequest::RequestPubMessage { value } => {
                 println!("WebSocket RequestPubMessage");
-                let _ret = self.domo_cache.pub_value(value.clone()).await;
+                self.domo_cache.pub_value(value.clone()).await;
             }
 
             _ => {}

--- a/src/domocache.rs
+++ b/src/domocache.rs
@@ -27,7 +27,7 @@ pub enum DomoEvent {
 // period at which we send messages containing our cache hash
 const SEND_CACHE_HASH_PERIOD: u8 = 5;
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct DomoCacheElement {
     pub topic_name: String,
     pub topic_uuid: String,
@@ -38,7 +38,7 @@ pub struct DomoCacheElement {
     pub republication_timestamp: u128,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct DomoCacheStateMessage {
     pub peer_id: String,
     pub cache_hash: u64,
@@ -89,6 +89,7 @@ impl<T: DomoPersistentStorage> Hash for DomoCache<T> {
 }
 
 impl<T: DomoPersistentStorage> DomoCache<T> {
+    #[allow(unused)]
     pub fn filter_with_topic_name(
         &self,
         topic_name: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,7 @@ async fn handle_user_input(line: io::Result<Option<String>>, domo_broker: &mut D
         Some("PUB") => {
             let value = args.next();
 
-            if value == None {
+            if value.is_none() {
                 println!("value is mandatory");
             }
 

--- a/src/webapimanager.rs
+++ b/src/webapimanager.rs
@@ -13,7 +13,7 @@ use axum::extract::ws::Message;
 use axum::extract::ws::WebSocketUpgrade;
 use axum::extract::Path;
 
-use tower_http::cors::{Any, Cors, CorsLayer};
+use tower_http::cors::{Any, CorsLayer};
 
 use crate::websocketmessage::{
     AsyncWebSocketDomoMessage, SyncWebSocketDomoMessage, SyncWebSocketDomoRequest,
@@ -27,7 +27,6 @@ use tokio::sync::mpsc::Sender;
 
 use serde_json::json;
 
-use axum::http::{HeaderValue, Method};
 use nix::sys::socket::{self, sockopt::ReuseAddr, sockopt::ReusePort};
 use std::{net::TcpListener, os::unix::io::AsRawFd};
 


### PR DESCRIPTION
This fixes the currently failing clippy. The PR adds the ability to turn on the debug console via an environment variable. Before, the debug console was disabled at compile time by commenting out the part that listens for input, but this caused many dead code warnings.