### PR TITLE
Update libp2p to 0.50.0

### DIFF
--- a/.github/workflows/libp2p-rust-dht-ubuntu.yml
+++ b/.github/workflows/libp2p-rust-dht-ubuntu.yml
@@ -24,6 +24,10 @@ jobs:
         override: true
         components: clippy, rustfmt
 
+    - name: Install protobuf compiler
+      run: |
+        sudo apt-get install protobuf-compiler
+
     - name: Run rustfmt
       uses: actions-rs/cargo@v1
       with:
@@ -50,6 +54,10 @@ jobs:
         toolchain: stable
         override: true
 
+    - name: Install protobuf compiler
+      run: |
+        sudo apt-get install protobuf-compiler
+
     - name: Build
       run: cargo build --verbose --tests --benches
 
@@ -72,6 +80,10 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
+
+    - name: Install protobuf compiler
+      run: |
+        sudo apt-get install protobuf-compiler
 
     - name: Install grcov
       env:
@@ -153,6 +165,10 @@ jobs:
         toolchain: stable
         override: true
 
+    - name: Install protobuf compiler
+      run: |
+        sudo apt-get install protobuf-compiler
+
     - name: Install valgrind
       run: |
         sudo apt-get install valgrind
@@ -193,6 +209,10 @@ jobs:
         toolchain: nightly
         components: rust-src
         override: true
+
+    - name: Install protobuf compiler
+      run: |
+        sudo apt-get install protobuf-compiler
 
     # FIXME Use binaries
     - name: Install cargo-fuzz and cargo-careful
@@ -268,6 +288,10 @@ jobs:
         toolchain: stable
         override: true
 
+    - name: Install protobuf compiler
+      run: |
+        sudo apt-get install protobuf-compiler
+
     - name: Install grcov
       env:
         GRCOV_LINK: https://github.com/mozilla/grcov/releases/download
@@ -336,6 +360,10 @@ jobs:
       with:
         profile: minimal
         toolchain: nightly
+
+    - name: Install protobuf compiler
+      run: |
+        sudo apt-get install protobuf-compiler
 
     - name: Install cargo-udeps
       env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ chrono = "0.4.19"
 clap = { version = "3.1.18", features = ["derive"] }
 env_logger = "0.9.0"
 futures = "0.3.21"
-libp2p = { version = "0.44.0", features = ["tcp-tokio", "mdns"] }
+libp2p = { version = "0.50.0", features = ["tokio", "mdns", "gossipsub", "noise", "yamux", "pnet", "rsa", "tcp", "macros"] }
 log = "0.4.17"
 rusqlite = "0.27.0"
 serde = "1.0.137"

--- a/src/domocache.rs
+++ b/src/domocache.rs
@@ -4,6 +4,7 @@ use chrono::prelude::*;
 use futures::prelude::*;
 use libp2p::gossipsub::IdentTopic as Topic;
 use libp2p::identity::Keypair;
+use libp2p::mdns;
 use libp2p::swarm::SwarmEvent;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -402,7 +403,7 @@ impl<T: DomoPersistentStorage> DomoCache<T> {
                         }
                     }
                     SwarmEvent::Behaviour(crate::domolibp2p::OutEvent::Mdns(
-                        libp2p::mdns::MdnsEvent::Expired(list),
+                        mdns::Event::Expired(list),
                     )) => {
                         let local = Utc::now();
 
@@ -411,7 +412,7 @@ impl<T: DomoPersistentStorage> DomoCache<T> {
                         }
                     }
                     SwarmEvent::Behaviour(crate::domolibp2p::OutEvent::Mdns(
-                        libp2p::mdns::MdnsEvent::Discovered(list),
+                        mdns::Event::Discovered(list),
                     )) => {
                         let local = Utc::now();
                         for (peer, _) in list {


### PR DESCRIPTION
This is pretty important because there is a CVE associated with the current version of libp2p (caused by owning-ref).

It is not the only security issue but it is a starting point.