### PR TITLE
Replace chrono with time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ vendored = ["reqwest/native-tls-vendored", "rusqlite/bundled"]
 
 [dependencies]
 axum = { version = "0.5.6", features = ["ws"] }
-chrono = "0.4.19"
 clap = { version = "3.1.18", features = ["derive"] }
 env_logger = "0.9.0"
 futures = "0.3.21"
@@ -31,6 +30,7 @@ rsa = "0.6"
 pem-rfc7468 = "0.3"
 rand = "0.8"
 tower-http = { version = "0.3.0", features = ["cors"] }
+time = "0.3.17"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.24.1"

--- a/src/domocache.rs
+++ b/src/domocache.rs
@@ -1,6 +1,5 @@
 use crate::domopersistentstorage::DomoPersistentStorage;
 use crate::utils;
-use chrono::prelude::*;
 use futures::prelude::*;
 use libp2p::gossipsub::IdentTopic as Topic;
 use libp2p::identity::Keypair;
@@ -13,6 +12,7 @@ use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::time::Duration;
+use time::OffsetDateTime;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{Receiver, Sender};
 
@@ -404,7 +404,7 @@ impl<T: DomoPersistentStorage> DomoCache<T> {
                     SwarmEvent::Behaviour(crate::domolibp2p::OutEvent::Mdns(
                         libp2p::mdns::MdnsEvent::Expired(list),
                     )) => {
-                        let local = Utc::now();
+                        let local = OffsetDateTime::now_utc();
 
                         for (peer, _) in list {
                             log::info!("MDNS for peer {peer} expired {local:?}");
@@ -413,7 +413,7 @@ impl<T: DomoPersistentStorage> DomoCache<T> {
                     SwarmEvent::Behaviour(crate::domolibp2p::OutEvent::Mdns(
                         libp2p::mdns::MdnsEvent::Discovered(list),
                     )) => {
-                        let local = Utc::now();
+                        let local = OffsetDateTime::now_utc();
                         for (peer, _) in list {
                             self.swarm
                                 .behaviour_mut()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
 use serde_json::json;
+use time::OffsetDateTime;
 
 use std::error::Error;
-
-use chrono::prelude::*;
 
 use tokio::io::{self, AsyncBufReadExt};
 
@@ -41,7 +40,7 @@ struct Opt {
 async fn main() -> Result<(), Box<dyn Error>> {
     let opt = Opt::parse();
 
-    let local = Utc::now();
+    let local = OffsetDateTime::now_utc();
 
     log::info!("Program started at {:?}", local);
 


### PR DESCRIPTION
There are two open questions:
- the name of the variable associated to the UTC datetime is called `local`. Should be renamed the variable? Should we use `now_local`?
- the program is using the `Debug` format instead of `Display`. Should this be changed?