### PR TITLE
Simpler api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ env_logger = "0.9.0"
 futures = "0.3.21"
 libp2p = { version = "0.50.0", features = ["tokio", "mdns", "gossipsub", "noise", "yamux", "pnet", "rsa", "tcp", "macros"] }
 log = "0.4.17"
-rusqlite = "0.27.0"
+rusqlite = "0.28.0"
 serde = "1.0.137"
 serde_json = "1.0"
 tokio = { version = "1.19.0", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,5 @@ pub mod restmessage;
 pub mod utils;
 pub mod webapimanager;
 pub mod websocketmessage;
+
+pub use libp2p::identity::Keypair;


### PR DESCRIPTION
Re-export the Keypair so users won't have to keep libp2p in sync or even know about more than this specific detail.