### PR TITLE
Add a way to request rekeying on the websocket interface

### DIFF
--- a/src/domobroker.rs
+++ b/src/domobroker.rs
@@ -251,6 +251,14 @@ impl DomoBroker {
                     Err(_e) => log::debug!("Error while sending Rest Reponse"),
                 }
             }
+            restmessage::RestMessage::Rekey { new_key, responder } => {
+                let res = self.domo_cache.rekey(new_key).await;
+                let res_to_send = res.map(|_| json!({})).map_err(|_| String::new());
+                match responder.send(res_to_send) {
+                    Ok(_m) => log::debug!("Rest response ok"),
+                    Err(_e) => log::debug!("Error while sending Rest Reponse"),
+                }
+            }
             restmessage::RestMessage::PubMessage { value, responder } => {
                 self.domo_cache.pub_value(value.clone()).await;
                 match responder.send(Ok(value)) {

--- a/src/restmessage.rs
+++ b/src/restmessage.rs
@@ -27,6 +27,10 @@ pub enum RestMessage {
         value: serde_json::Value,
         responder: RestResponder,
     },
+    Rekey {
+        new_key: String,
+        responder: RestResponder,
+    },
     PubMessage {
         value: serde_json::Value,
         responder: RestResponder,


### PR DESCRIPTION
This adds a way to issue a rekeying command from the websocket interface, so that one doesn't have to restart the entire DHT as well as all nodes connected to it.