### PR TITLE
Make domolibp2p generic on the topics specified

### DIFF
--- a/src/domocache.rs
+++ b/src/domocache.rs
@@ -438,7 +438,7 @@ impl<T: DomoPersistentStorage> DomoCache<T> {
         local_key_pair: Keypair,
         loopback_only: bool,
     ) -> Self {
-        let swarm = crate::domolibp2p::start(shared_key, local_key_pair, loopback_only)
+        let swarm = crate::domolibp2p::start(&shared_key, local_key_pair, loopback_only)
             .await
             .unwrap();
 


### PR DESCRIPTION
This makes the domolibp2p layer generic on the topics and allows it to be used from other components. My intent is to use it in the node-manager for the lobby network, but if this won't be merged then I will copy paste the module. Not the best solution but it would work.

This PR does not change any functionality so it should be easy to merge it.