### PR TITLE
Housekeeping

### DIFF
--- a/.github/workflows/libp2p-rust-dht.yml
+++ b/.github/workflows/libp2p-rust-dht.yml
@@ -545,35 +545,3 @@ jobs:
       # Usage of the `help` command as base command, please replace it
       # with the effective command that AddressSanitizer has to analyze
       # run: cargo run -Zbuild-std --target x86_64-unknown-linux-gnu -- --help
-
-################################## FUZZY LEVEL #################################
-
-  fuzzy:
-
-    needs: [valgrind, careful, address-sanitizer]
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Install protobuf compiler
-      run: |
-        sudo apt-get update
-        sudo apt-get install protobuf-compiler
-
-    - name: Install Rust nightly
-      uses: dtolnay/rust-toolchain@nightly
-      with:
-        toolchain: nightly
-
-    - name: Install cargo-fuzz
-      env:
-        FUZZ_LINK: https://github.com/rust-fuzz/cargo-fuzz/releases/download
-        FUZZ_VERSION: 0.11.2
-      run: |
-        curl -L "$FUZZ_LINK/$FUZZ_VERSION/cargo-fuzz-$FUZZ_VERSION-x86_64-unknown-linux-musl.tar.gz" |
-        tar xz -C $HOME/.cargo/bin
-
-    - name: Run cargo-fuzz
-      run: cargo fuzz build --target x86_64-unknown-linux-gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1.19.0", features = ["full"] }
 tokio-tungstenite = "0.17.1"
 tower-http = { version = "0.3.0", features = ["cors"] }
 url = "2.2.2"
+enum-as-inner = "=0.5.1"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.24.1"

--- a/dht-cache/src/domolibp2p.rs
+++ b/dht-cache/src/domolibp2p.rs
@@ -16,7 +16,7 @@ use libp2p::core::{muxing::StreamMuxerBox, transport, transport::upgrade::Versio
 
 use libp2p::noise;
 use libp2p::pnet::{PnetConfig, PreSharedKey};
-use libp2p::yamux::YamuxConfig;
+use libp2p::yamux;
 //use libp2p::tcp::TcpConfig;
 use libp2p::Transport;
 
@@ -50,11 +50,8 @@ pub fn build_transport(
     key_pair: identity::Keypair,
     psk: PreSharedKey,
 ) -> transport::Boxed<(PeerId, StreamMuxerBox)> {
-    let noise_keys = noise::Keypair::<noise::X25519Spec>::new()
-        .into_authentic(&key_pair)
-        .unwrap();
-    let noise_config = noise::NoiseConfig::xx(noise_keys).into_authenticated();
-    let yamux_config = YamuxConfig::default();
+    let noise_config = noise::Config::new(&key_pair).unwrap();
+    let yamux_config = yamux::Config::default();
 
     let base_transport = tcp::tokio::Transport::new(tcp::Config::default().nodelay(true));
 


### PR DESCRIPTION
Triggered by the botched release of `enum-as-inner` that caused https://github.com/bluejekyll/enum-as-inner/issues/98.

I decided to clean up also few new warnings.