### PR TITLE
Pin libc version

### DIFF
--- a/dht-cache/Cargo.toml
+++ b/dht-cache/Cargo.toml
@@ -28,7 +28,8 @@ pem-rfc7468 = { version = "0.7", features = ["alloc"] }
 sifis-config = { path = "../dht-config" }
 openssl-sys = "*"
 libsqlite3-sys = "*"
+libc = "=0.2.144"
 
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["openssl-sys", "libsqlite3-sys"]
+normal = ["openssl-sys", "libsqlite3-sys", "libc"]


### PR DESCRIPTION
libc 0.2.145 seems to have botched the open vs open64 and that impacts getrandom that we use through libp2p.

Pin to 0.2.144 for the time being and revisit once the problem is solved.