### PR TITLE
Better length error

### DIFF
--- a/dht-cache/src/domolibp2p.rs
+++ b/dht-cache/src/domolibp2p.rs
@@ -42,7 +42,7 @@ fn parse_hex_key(s: &str) -> Result<[u8; KEY_SIZE], String> {
         }
         Ok(r)
     } else {
-        Err(String::from("Len Error"))
+        Err(format!("Len Error: expected {} but got {}", KEY_SIZE * 2, s.len()))
     }
 }
 


### PR DESCRIPTION
This makes the dht emit better length errors. Often I'm seeing these errors and I wonder where they are coming from. It is better to have the length printed.